### PR TITLE
Support the .mjs file extension

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -21,7 +21,7 @@ module.exports = class Shrimpit {
     // Remove execPath and path from argv.
     const [, , ...src] = argv
 
-    this.allowedTypes = /^\.(jsx?|tsx?|vue)$/
+    this.allowedTypes = /^\.(mjs|jsx?|tsx?|vue)$/
     this.filesTree = {}
     this.namespaceImports = []
     this.isVueTemplate = /^\.vue$/


### PR DESCRIPTION
At the moment, `.mjs` files are excluded from analysis, even if you supply a glob containing this extension. `.mjs` is the file extension for ESM, and is recognised by Node.js and other tools such as Webpack.